### PR TITLE
Show Loader when the user creates an article #14

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -14,6 +14,8 @@
         <entry key="../../../../../../layout/compose-model-1646838841788.xml" value="0.24351851851851852" />
         <entry key="../../../../../../layout/compose-model-1646845059552.xml" value="0.1" />
         <entry key="../../../../../../layout/compose-model-1646924075778.xml" value="0.19425675675675674" />
+        <entry key="../../../../../../layout/compose-model-1647023253187.xml" value="0.1" />
+        <entry key="../../../../../../layout/compose-model-1647035711329.xml" value="0.3488636363636364" />
         <entry key="../../../../layout/compose-model-1645541257205.xml" value="0.16540404040404041" />
         <entry key="../../../../layout/compose-model-1645548663479.xml" value="0.2972222222222222" />
         <entry key="../../../../layout/compose-model-1646155249916.xml" value="0.33" />

--- a/app/src/main/java/com/wizeline/mobilenews/ui/common/GradientButton.kt
+++ b/app/src/main/java/com/wizeline/mobilenews/ui/common/GradientButton.kt
@@ -1,7 +1,10 @@
 package com.wizeline.mobilenews.ui.common
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
@@ -27,6 +30,7 @@ fun GradientButton(
             Capri
         )
     ),
+    enabled: Boolean = true,
     onClick: () -> Unit
 ) {
     Button(
@@ -36,10 +40,12 @@ fun GradientButton(
         contentPadding = PaddingValues(),
         onClick = onClick,
         modifier = modifier,
+        enabled = enabled,
         shape = RoundedCornerShape(30.dp)
     ) {
         Box(
-            modifier = Modifier.weight(1f)
+            modifier = Modifier
+                .weight(1f)
                 .background(gradient, RoundedCornerShape(30.dp))
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             contentAlignment = Alignment.Center

--- a/app/src/main/java/com/wizeline/mobilenews/ui/common/Snackbar.kt
+++ b/app/src/main/java/com/wizeline/mobilenews/ui/common/Snackbar.kt
@@ -1,0 +1,32 @@
+package com.wizeline.mobilenews.ui.common
+
+import android.annotation.SuppressLint
+import androidx.compose.material.Button
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.rememberScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
+
+@SuppressLint("CoroutineCreationDuringComposition")
+@Composable
+fun CustomSnackbar(text: String) {
+    val scaffoldState = rememberScaffoldState()
+    val snackbarCoroutineScope = rememberCoroutineScope()
+
+    Scaffold(scaffoldState = scaffoldState) {
+        Button(onClick = {
+            snackbarCoroutineScope.launch {
+                scaffoldState.snackbarHostState.showSnackbar(text)
+            }
+        }) {
+            Text(text)
+        }
+    }
+
+    snackbarCoroutineScope.launch {
+        if (text.isNotEmpty())
+            scaffoldState.snackbarHostState.showSnackbar(text)
+    }
+}

--- a/app/src/main/java/com/wizeline/mobilenews/ui/createArticle/CreateArticleViewModel.kt
+++ b/app/src/main/java/com/wizeline/mobilenews/ui/createArticle/CreateArticleViewModel.kt
@@ -1,9 +1,9 @@
 package com.wizeline.mobilenews.ui.createArticle
 
 import android.net.Uri
-import android.util.Log
-import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wizeline.mobilenews.EMPTY_STRING
@@ -21,52 +21,53 @@ class CreateArticleViewModel @Inject constructor(val saveCommunityArticleUseCase
 
     private val authorNameRegex = "^(?![ .]+$)[a-zA-ZÀ-ú .\n]*$".toRegex()
 
-    val articleName: MutableState<String> = mutableStateOf(EMPTY_STRING)
-    val articleAuthor: MutableState<String> = mutableStateOf(EMPTY_STRING)
-    val articleDescription: MutableState<String> = mutableStateOf(EMPTY_STRING)
-    val imageUri: MutableState<Uri?> = mutableStateOf(Uri.EMPTY)
-    val uiState: MutableState<UiState> = mutableStateOf(UiState.NoState)
+    var articleTitle: String by mutableStateOf(EMPTY_STRING)
+        private set
+    var articleAuthor: String by mutableStateOf(EMPTY_STRING)
+        private set
+    var articleDescription: String by mutableStateOf(EMPTY_STRING)
+        private set
+    var imageUri: Uri? by mutableStateOf(Uri.EMPTY)
+        private set
+    var uiState: UiState by mutableStateOf(UiState.NoState)
+        private set
 
     suspend fun createCommunityPost() {
         val formComplete = allFieldsCorrect()
 
         if (formComplete is UiState.MissingFieldAction) {
-            uiState.value = formComplete
+            uiState = formComplete
             return
         }
 
         val communityArticle = CommunityArticle(
-            title = articleName.value,
-            author = articleAuthor.value,
-            text = articleDescription.value,
+            title = articleTitle,
+            author = articleAuthor,
+            text = articleDescription,
             publishedDate = System.currentTimeMillis(),
         )
 
         viewModelScope.launch(Dispatchers.IO) {
-            uiState.value = UiState.LoadingState
+            uiState = UiState.LoadingState
             val response =
-                saveCommunityArticleUseCase(communityArticle, imageUri.value ?: Uri.EMPTY)
+                saveCommunityArticleUseCase(communityArticle, imageUri ?: Uri.EMPTY)
             if (response is NetworkResults.Success) {
-                uiState.value = UiState.RequestCompleted("Post successfully created!")
+                uiState = UiState.RequestCompleted("Post successfully created!")
                 return@launch
             }
         }
-
-        //Upload image to firebase
-        Log.i("CreateViewModel", communityArticle.toString())
     }
 
     private fun allFieldsCorrect(): UiState {
-        Log.i("CreateViewModel", imageUri.value.toString().trim())
-        return if (articleName.value.trim().isEmpty()) {
+        return if (articleTitle.trim().isEmpty()) {
             UiState.MissingFieldAction("The post title should not be empty")
-        } else if (articleAuthor.value.trim().isEmpty()) {
+        } else if (articleAuthor.trim().isEmpty()) {
             UiState.MissingFieldAction("The post author should not be empty")
-        } else if (!authorNameRegex.matches(articleAuthor.value)) {
+        } else if (!authorNameRegex.matches(articleAuthor)) {
             UiState.MissingFieldAction("The post author is invalid, no special characters nor numbers allowed")
-        } else if (articleDescription.value.trim().isEmpty()) {
+        } else if (articleDescription.trim().isEmpty()) {
             UiState.MissingFieldAction("The post description should not be empty")
-        } else if (imageUri.value.toString().trim().isEmpty()) {
+        } else if (imageUri.toString().trim().isEmpty()) {
             UiState.MissingFieldAction("You have to select an image")
         } else {
             UiState.NoState
@@ -81,6 +82,26 @@ class CreateArticleViewModel @Inject constructor(val saveCommunityArticleUseCase
         ) : UiState()
 
         data class RequestCompleted(val message: String) : UiState()
+    }
+
+    fun updateArticleTitle(newTitle: String) {
+        this.articleTitle = newTitle
+    }
+
+    fun updateArticleAuthor(newAuthor: String) {
+        this.articleAuthor = newAuthor
+    }
+
+    fun updateArticleDescription(newDescription: String) {
+        this.articleDescription = newDescription
+    }
+
+    fun updateImageUri(newImageUri: Uri) {
+        imageUri = newImageUri
+    }
+
+    fun restartUiState() {
+        uiState = UiState.NoState
     }
 
 }

--- a/app/src/main/java/com/wizeline/mobilenews/ui/custom/LoadingProgressBar.kt
+++ b/app/src/main/java/com/wizeline/mobilenews/ui/custom/LoadingProgressBar.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun LoadingItem() {
+fun LoadingProgressBar() {
     CircularProgressIndicator(
         modifier =
         Modifier

--- a/app/src/main/java/com/wizeline/mobilenews/ui/dashboard/Dashboard.kt
+++ b/app/src/main/java/com/wizeline/mobilenews/ui/dashboard/Dashboard.kt
@@ -16,7 +16,7 @@ import androidx.lifecycle.asFlow
 import androidx.navigation.NavController
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
-import com.wizeline.mobilenews.ui.custom.LoadingItem
+import com.wizeline.mobilenews.ui.custom.LoadingProgressBar
 import com.wizeline.mobilenews.ui.custom.ShowErrorOrDialog
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
@@ -62,10 +62,10 @@ fun Dashboard(navController: NavController) {
                     list.apply {
                         when {
                             loadState.refresh is LoadState.Loading -> {
-                                item { LoadingItem() }
+                                item { LoadingProgressBar() }
                             }
                             loadState.append is LoadState.Loading -> {
-                                item { LoadingItem() }
+                                item { LoadingProgressBar() }
                             }
                             loadState.refresh is LoadState.Error -> {
                                 item { ShowErrorOrDialog(loadState.refresh as LoadState.Error) }

--- a/app/src/main/java/com/wizeline/mobilenews/ui/dashboard/GlobalNewsPage.kt
+++ b/app/src/main/java/com/wizeline/mobilenews/ui/dashboard/GlobalNewsPage.kt
@@ -14,7 +14,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.wizeline.mobilenews.HALF_PAST_ITEM_LEFT
 import com.wizeline.mobilenews.HALF_PAST_ITEM_RIGHT
 import com.wizeline.mobilenews.ui.custom.CustomScrollableArticle
-import com.wizeline.mobilenews.ui.custom.LoadingItem
+import com.wizeline.mobilenews.ui.custom.LoadingProgressBar
 import com.wizeline.mobilenews.ui.custom.ShowErrorOrDialog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -36,13 +36,13 @@ fun GlobalNewsPage() {
             items(lazyArticles.itemCount) { index ->
                 lazyArticles[index]?.let { article -> CustomScrollableArticle(article) }
 
-                if(!listState.isScrollInProgress){
-                    if(listState.isHalfPastItemLeft())
+                if (!listState.isScrollInProgress) {
+                    if (listState.isHalfPastItemLeft())
                         coroutineScope.scrollBasic(listState, left = true)
                     else
                         coroutineScope.scrollBasic(listState)
 
-                    if(listState.isHalfPastItemRight())
+                    if (listState.isHalfPastItemRight())
                         coroutineScope.scrollBasic(listState)
                     else
                         coroutineScope.scrollBasic(listState, left = true)
@@ -51,10 +51,10 @@ fun GlobalNewsPage() {
             lazyArticles.apply {
                 when {
                     loadState.refresh is LoadState.Loading -> {
-                        item { LoadingItem() }
+                        item { LoadingProgressBar() }
                     }
                     loadState.append is LoadState.Loading -> {
-                        item { LoadingItem() }
+                        item { LoadingProgressBar() }
                     }
                     loadState.refresh is LoadState.Error -> {
                         item { ShowErrorOrDialog(loadState.refresh as LoadState.Error) }
@@ -69,9 +69,9 @@ fun GlobalNewsPage() {
 }
 
 //TODO: Make extensions file and import
-private fun CoroutineScope.scrollBasic(listState: LazyListState, left: Boolean = false){
+private fun CoroutineScope.scrollBasic(listState: LazyListState, left: Boolean = false) {
     launch {
-        val pos = if(left) listState.firstVisibleItemIndex else listState.firstVisibleItemIndex+1
+        val pos = if (left) listState.firstVisibleItemIndex else listState.firstVisibleItemIndex + 1
         listState.animateScrollToItem(pos)
     }
 }


### PR DESCRIPTION
+ Removed use of Toasts and instead use Snackbars.
+ Refactor the use of read-only properties from the viewmodel.
+ Usage of a loader when the user waits for the create article response.
+ Code cleanup and refactor.
+ Removed unused imports.